### PR TITLE
Add uppercase option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "out/src",
+            "outFiles": [
+                "${workspaceRoot}/out/**/*.js"
+            ],
             "preLaunchTask": "npm"
         },
         {
@@ -25,7 +27,9 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "out/test",
+            "outFiles": [
+                "${workspaceRoot}/out/**/*.js"
+            ],
             "preLaunchTask": "npm"
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,6 @@
         "--loglevel",
         "silent"
     ],
-    "isWatching": true,
+    "isBackground": true,
     "problemMatcher": "$tsc-watch"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@
 var gulp = require('gulp');
 var clean = require('gulp-clean');
 var merge = require('gulp-merge');
+var sourcemaps = require('gulp-sourcemaps');
 var svgmin = require('gulp-svgmin');
 var ts = require('gulp-typescript');
 
@@ -33,8 +34,11 @@ gulp.task('compile', function() {
             .pipe(svgmin())
             .pipe(gulp.dest('out/res/')),
         project.src()
+            .pipe(sourcemaps.init())
             .pipe(ts(project))
-            .js.pipe(gulp.dest('out'))
+            .js
+            .pipe(sourcemaps.write('./', { sourceRoot: '../' }))
+            .pipe(gulp.dest('out'))
     );
 });
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,26 @@
         "description": "Insert a GUID at the current position."
       }
     ],
+    "configuration": {
+      "title": "Insert GUID configuration",
+        "properties": {
+            "insertGuid.showLowercase": {
+              "type": "boolean",
+              "default": true,
+              "description": "Show lowercase GUIDs (with and without braces) when presenting possible GUID formats to insert."
+            },
+            "insertGuid.showUppercase": {
+              "type": "boolean",
+              "default": false,
+              "description": "Show uppercase GUIDs (with and without braces) when presenting possible GUID formats to insert."
+            },
+            "insertGuid.showCodeSnippets": {
+              "type": "boolean",
+              "default": true,
+              "description": "Show code snippets for C++ when presenting possible GUID formats to insert."
+            }
+        }
+    },
     "keybindings": [
       {
         "command": "guid.insert",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-clean": "^0.3.1",
     "gulp-merge": "^0.1.1",
     "gulp-svgmin": "^1.2.1",
+    "gulp-sourcemaps": "^2.6.0",
     "gulp-typescript": "^2.10.0",
     "tsd": "^0.6.5",
     "typescript": "^1.6.2",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -73,7 +73,7 @@ suite('GuidCommands', () => {
         );
     });
 
-    test('quick pick iterms are correct with only lowercase enabled', () => {
+    test('quick pick items are correct with only lowercase enabled', () => {
         const g = Guid.parse('12341234-dead-beef-1234-123412341234');
         const items = GuidCommands.getQuickPickItems(g, true, false, false);
 
@@ -90,7 +90,7 @@ suite('GuidCommands', () => {
         assert.equal(item2.text, '{12341234-dead-beef-1234-123412341234}');
     });
 
-    test('quick pick iterms are correct with only uppercase enabled', () => {
+    test('quick pick items are correct with only uppercase enabled', () => {
         const g = Guid.parse('12341234-dead-beef-1234-123412341234');
         const items = GuidCommands.getQuickPickItems(g, false, true, false);
 
@@ -108,7 +108,7 @@ suite('GuidCommands', () => {
     });
 
 
-    test('quick pick iterms are correct with only code snippets enabled', () => {
+    test('quick pick items are correct with only code snippets enabled', () => {
         const g = Guid.parse('12341234-dead-beef-1234-123412341234');
         const items = GuidCommands.getQuickPickItems(g, false, true, false);
 
@@ -135,7 +135,7 @@ suite('GuidCommands', () => {
         );
     });
 
-    test('quick pick iterms are correct with no code snippets enabled', () => {
+    test('quick pick items are correct with no code snippets enabled', () => {
         var g = Guid.parse('12341234-1234-1234-1234-123412341234');
         var items = GuidCommands.getQuickPickItems(g, false, false, false);
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -26,6 +26,64 @@ import {Guid} from '../src/guid';
 import {GuidCommands} from '../src/commands';
 
 suite('GuidCommands', () => {
+    test('quick pick 1 is simple string with default options', () => {
+        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
+        var items = GuidCommands.getQuickPickItems(g, true, false, true);
+
+        assert.equal(items.length, 4);
+
+        var item = items[0];
+        assert.strictEqual(item.label, '1');
+        assert.equal(item.description, '12341234-1234-1234-1234-123412341234');
+        assert.equal(item.text, '12341234-1234-1234-1234-123412341234');
+    });
+
+    test('quick pick 2 is registry string with default options', () => {
+        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
+        var items = GuidCommands.getQuickPickItems(g, true, false, true);
+
+        assert.equal(items.length, 4);
+
+        var item = items[1];
+        assert.strictEqual(item.label, '2');
+        assert.equal(item.description, '{12341234-1234-1234-1234-123412341234}');
+        assert.equal(item.text, '{12341234-1234-1234-1234-123412341234}');
+    });
+
+    test('quick pick 3 is C structure with default options', () => {
+        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
+        var items = GuidCommands.getQuickPickItems(g, true, false, true);
+
+        assert.equal(items.length, 4);
+
+        var item = items[2];
+        assert.strictEqual(item.label, '3');
+        assert.equal(item.description,
+            'static const struct GUID __NAME__ = {0x12341234, 0x1234, 0x1234, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};'
+        );
+        assert.equal(item.text,
+            '// {12341234-1234-1234-1234-123412341234}\n' +
+            'static const struct GUID __NAME__ = {0x12341234, 0x1234, 0x1234, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};\n'
+        );
+    });
+
+    test('quick pick 4 is C macro with default options', () => {
+        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
+        var items = GuidCommands.getQuickPickItems(g, true, false, true);
+
+        assert.equal(items.length, 4);
+
+        var item = items[3];
+        assert.strictEqual(item.label, '4');
+        assert.equal(item.description,
+            'DEFINE_GUID(__NAME__, 0x12341234, 0x1234, 0x1234, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);'
+        );
+        assert.equal(item.text,
+            '// {12341234-1234-1234-1234-123412341234}\n' +
+            'DEFINE_GUID(__NAME__, 0x12341234, 0x1234, 0x1234, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);\n'
+        );
+    });
+
     test('quick pick items are correct when all settings are true', () => {
         const g = Guid.parse('12341234-dead-beef-1234-123412341234');
         const items = GuidCommands.getQuickPickItems(g, true, true, true);

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -26,61 +26,130 @@ import {Guid} from '../src/guid';
 import {GuidCommands} from '../src/commands';
 
 suite('GuidCommands', () => {
-    test('quick pick 1 is simple string', () => {
-        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
-        var items = GuidCommands.getQuickPickItems(g);
+    test('quick pick items are correct when all settings are true', () => {
+        const g = Guid.parse('12341234-dead-beef-1234-123412341234');
+        const items = GuidCommands.getQuickPickItems(g, true, true, true);
 
-        assert.equal(items.length, 4);
+        assert.equal(items.length, 6);
 
-        var item = items[0];
-        assert.strictEqual(item.label, '1');
-        assert.equal(item.description, '12341234-1234-1234-1234-123412341234');
-        assert.equal(item.text, '12341234-1234-1234-1234-123412341234');
-    });
+        const item1 = items[0];
+        assert.strictEqual(item1.label, '1');
+        assert.equal(item1.description, '12341234-dead-beef-1234-123412341234');
+        assert.equal(item1.text, '12341234-dead-beef-1234-123412341234');
 
-    test('quick pick 2 is registry string', () => {
-        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
-        var items = GuidCommands.getQuickPickItems(g);
+        const item2 = items[1];
+        assert.strictEqual(item2.label, '2');
+        assert.equal(item2.description, '{12341234-dead-beef-1234-123412341234}');
+        assert.equal(item2.text, '{12341234-dead-beef-1234-123412341234}');
 
-        assert.equal(items.length, 4);
+        const item3 = items[2];
+        assert.strictEqual(item3.label, '3');
+        assert.equal(item3.description, '12341234-DEAD-BEEF-1234-123412341234');
+        assert.equal(item3.text, '12341234-DEAD-BEEF-1234-123412341234');
 
-        var item = items[1];
-        assert.strictEqual(item.label, '2');
-        assert.equal(item.description, '{12341234-1234-1234-1234-123412341234}');
-        assert.equal(item.text, '{12341234-1234-1234-1234-123412341234}');
-    });
+        const item4 = items[3];
+        assert.strictEqual(item4.label, '4');
+        assert.equal(item4.description, '{12341234-DEAD-BEEF-1234-123412341234}');
+        assert.equal(item4.text, '{12341234-DEAD-BEEF-1234-123412341234}');
 
-    test('quick pick 3 is C structure', () => {
-        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
-        var items = GuidCommands.getQuickPickItems(g);
-
-        assert.equal(items.length, 4);
-
-        var item = items[2];
-        assert.strictEqual(item.label, '3');
-        assert.equal(item.description,
-            'static const struct GUID __NAME__ = {0x12341234, 0x1234, 0x1234, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};'
+        const item5 = items[4];
+        assert.strictEqual(item5.label, '5');
+        assert.equal(item5.description,
+            'static const struct GUID __NAME__ = {0x12341234, 0xdead, 0xbeef, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};'
         );
-        assert.equal(item.text,
+        assert.equal(item5.text,
             '// {12341234-1234-1234-1234-123412341234}\n' +
-            'static const struct GUID __NAME__ = {0x12341234, 0x1234, 0x1234, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};\n'
+            'static const struct GUID __NAME__ = {0x12341234, 0xdead, 0xbeef, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};\n'
+        );
+
+        const item6 = items[5];
+        assert.strictEqual(item5.label, '6');
+        assert.equal(item6.description,
+            'DEFINE_GUID(__NAME__, 0x12341234, 0xdead, 0xbeef, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);'
+        );
+        assert.equal(item6.text,
+            '// {12341234-1234-1234-1234-123412341234}\n' +
+            'DEFINE_GUID(__NAME__, 0x12341234, 0xdead, 0xbeef, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);\n'
         );
     });
 
-    test('quick pick 4 is C macro', () => {
-        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
-        var items = GuidCommands.getQuickPickItems(g);
+    test('quick pick iterms are correct with only lowercase enabled', () => {
+        const g = Guid.parse('12341234-dead-beef-1234-123412341234');
+        const items = GuidCommands.getQuickPickItems(g, true, false, false);
 
-        assert.equal(items.length, 4);
+        assert.equal(items.length, 2);
 
-        var item = items[3];
-        assert.strictEqual(item.label, '4');
-        assert.equal(item.description,
-            'DEFINE_GUID(__NAME__, 0x12341234, 0x1234, 0x1234, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);'
+        const item1 = items[0];
+        assert.strictEqual(item1.label, '1');
+        assert.equal(item1.description, '12341234-dead-beef-1234-123412341234');
+        assert.equal(item1.text, '12341234-dead-beef-1234-123412341234');
+
+        const item2 = items[1];
+        assert.strictEqual(item2.label, '2');
+        assert.equal(item2.description, '{12341234-dead-beef-1234-123412341234}');
+        assert.equal(item2.text, '{12341234-dead-beef-1234-123412341234}');
+    });
+
+    test('quick pick iterms are correct with only uppercase enabled', () => {
+        const g = Guid.parse('12341234-dead-beef-1234-123412341234');
+        const items = GuidCommands.getQuickPickItems(g, false, true, false);
+
+        assert.equal(items.length, 2);
+
+        const item1 = items[0];
+        assert.strictEqual(item1.label, '1');
+        assert.equal(item1.description, '12341234-DEAD-BEEF-1234-123412341234');
+        assert.equal(item1.text, '12341234-DEAD-BEEF-1234-123412341234');
+
+        const item2 = items[1];
+        assert.strictEqual(item2.label, '2');
+        assert.equal(item2.description, '{12341234-DEAD-BEEF-1234-123412341234}');
+        assert.equal(item2.text, '{12341234-DEAD-BEEF-1234-123412341234}');
+    });
+
+
+    test('quick pick iterms are correct with only code snippets enabled', () => {
+        const g = Guid.parse('12341234-dead-beef-1234-123412341234');
+        const items = GuidCommands.getQuickPickItems(g, false, true, false);
+
+        assert.equal(items.length, 2);
+
+        const item1 = items[0];
+        assert.strictEqual(item1.label, '5');
+        assert.equal(item1.description,
+            'static const struct GUID __NAME__ = {0x12341234, 0xdead, 0xbeef, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};'
         );
-        assert.equal(item.text,
+        assert.equal(item1.text,
             '// {12341234-1234-1234-1234-123412341234}\n' +
-            'DEFINE_GUID(__NAME__, 0x12341234, 0x1234, 0x1234, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);\n'
+            'static const struct GUID __NAME__ = {0x12341234, 0xdead, 0xbeef, {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34}};\n'
         );
+
+        const item2 = items[1];
+        assert.strictEqual(item1.label, '6');
+        assert.equal(item2.description,
+            'DEFINE_GUID(__NAME__, 0x12341234, 0xdead, 0xbeef, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);'
+        );
+        assert.equal(item2.text,
+            '// {12341234-1234-1234-1234-123412341234}\n' +
+            'DEFINE_GUID(__NAME__, 0x12341234, 0xdead, 0xbeef, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34);\n'
+        );
+    });
+
+    test('quick pick iterms are correct with no code snippets enabled', () => {
+        var g = Guid.parse('12341234-1234-1234-1234-123412341234');
+        var items = GuidCommands.getQuickPickItems(g, false, false, false);
+
+        assert.equal(items.length, 2);
+
+        // with all options set to false, only the lowercase options are shown
+        const item1 = items[0];
+        assert.strictEqual(item1.label, '1');
+        assert.equal(item1.description, '12341234-dead-beef-1234-123412341234');
+        assert.equal(item1.text, '12341234-dead-beef-1234-123412341234');
+
+        const item2 = items[1];
+        assert.strictEqual(item2.label, '2');
+        assert.equal(item2.description, '{12341234-dead-beef-1234-123412341234}');
+        assert.equal(item2.text, '{12341234-dead-beef-1234-123412341234}');
     });
 });


### PR DESCRIPTION
This adds options to the GUID inserter:

- `insertGuid.showLowercase`
- `insertGuid.showUppercase`
- `insertGuid.showCodeSnippets`

By default, they are set with lowercase and code snippets on to match the old behaviour.  If they are all set to false, then just the lowercase options are shown.

Closes #6.