### PR TITLE
Fix workflow and resolve dev vulnerabilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,6 @@ insert_final_newline = true
 
 [*.json]
 indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - '8.x'
+        - '10.x'
         os:
         - macos-latest
         - ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         - '10.x'
         os:
         - macos-latest
-        - ubuntu-16.04
+        - ubuntu-latest
         - windows-latest
         vscode-channel:
         - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,18 @@ jobs:
     - name: Compile
       run: node ./node_modules/gulp/bin/gulp set-version compile
 
-    - name: Start Xvfb
-      run: |
-        set -e
-        /usr/bin/Xvfb :10 -ac >> /tmp/Xvfb.out 2>&1 &
-        disown -ar
+    - name: Test (Linux)
       if: runner.os == 'Linux'
+      run: xvfb-run -a node ./out/test/runTest
+      env:
+        CODE_VERSION: ${{ matrix.vscode-channel }}
+        TEST_RESULTS_PATH: ${{ github.workspace }}/.vscode-test/test-results.xml
 
     - name: Test
+      if: runner.os != 'Linux'
       run: node ./out/test/runTest
       env:
         CODE_VERSION: ${{ matrix.vscode-channel }}
-        DISPLAY: ':10'
         TEST_RESULTS_PATH: ${{ github.workspace }}/.vscode-test/test-results.xml
 
     - name: Publish test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,18 +43,18 @@ jobs:
       run: npm install
 
     - name: Compile
-      run: node ./node_modules/gulp/bin/gulp set-version compile
+      run: npm run compile set-version
 
     - name: Test (Linux)
       if: runner.os == 'Linux'
-      run: xvfb-run -a node ./out/test/runTest
+      run: xvfb-run -a npm test
       env:
         CODE_VERSION: ${{ matrix.vscode-channel }}
         TEST_RESULTS_PATH: ${{ github.workspace }}/.vscode-test/test-results.xml
 
     - name: Test
       if: runner.os != 'Linux'
-      run: node ./out/test/runTest
+      run: npm test
       env:
         CODE_VERSION: ${{ matrix.vscode-channel }}
         TEST_RESULTS_PATH: ${{ github.workspace }}/.vscode-test/test-results.xml
@@ -81,6 +81,14 @@ jobs:
       with:
         name: artifacts
         path: ${{ runner.temp }}/vscode-guid-${{ env.BUILD_VERSION }}.vsix
+
+  check:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check
+      run: echo "All required checks passed"
 
   publish:
     needs: build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ const clean = require('gulp-clean');
 const sourcemaps = require('gulp-sourcemaps');
 const svg2png = require('gulp-svg2png');
 const ts = require('gulp-typescript');
+const gh = require('@actions/core');
 
 gulp.task('compile:res', () => {
     return gulp.src('res/**/*.svg')
@@ -56,7 +57,7 @@ gulp.task('set-version', (done) => {
         console.log(`##vso[build.updatebuildnumber]${p.version}`);
     }
     else if (process.env.GITHUB_ACTIONS) {
-        console.log(`::set-env name=BUILD_VERSION::${p.version}`);
+        gh.exportVariable('BUILD_VERSION', p.version);
     }
 
     done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==",
+      "dev": true
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2951,9 +2951,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "interpret": {
@@ -3418,9 +3418,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._basecopy": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@actions/core": "^1.2.6",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.11.3",


### PR DESCRIPTION
Fixes the GitHub Actions workflow to use @actions/core instead of sending `::set-env` directly (deprecated), and closes vulnerabilities @dependabot discovered since I had to fix the workflow anyway.

Closes #34 and closes #35