### PR TITLE
Add windows-rs format

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,7 +28,7 @@ enum FormatType {
     LOWERCASE,
     UPPERCASE,
     SNIPPET,
-    CUSTOM
+    CUSTOM,
 }
 
 enum GuidGenerateType {
@@ -158,6 +158,19 @@ const FORMATS: GuidPickFormat[] = [
     {
         format: (g) => {
             return g.toString('x');
+        },
+        type: FormatType.SNIPPET
+    },
+    {
+        named: true,
+        format: (g) => {
+            return util.format('const %s: GUID = GUID%s;', NAME_PLACEHOLDER, g.toString('structrs'));
+        },
+        preface: (g) => {
+            return util.format('// %s\n', g.toString('braced'));
+        },
+        epilogue: (g) => {
+            return '\n';
         },
         type: FormatType.SNIPPET
     },

--- a/src/guid.ts
+++ b/src/guid.ts
@@ -90,6 +90,12 @@ export class Guid {
                 b.toString('hex', 8, 9), b.toString('hex', 9, 10),
                 b.toString('hex', 10, 11), b.toString('hex', 11, 12), b.toString('hex', 12, 13),
                 b.toString('hex', 13, 14), b.toString('hex', 14, 15), b.toString('hex', 15, 16));
+        } else if (format === 'structrs') {
+            return util.format('{data1: 0x%s, data2: 0x%s, data3: 0x%s, data4: [0x%s, 0x%s, 0x%s, 0x%s, 0x%s, 0x%s, 0x%s, 0x%s]}',
+                b.toString('hex', 0, 4), b.toString('hex', 4, 6), b.toString('hex', 6, 8),
+                b.toString('hex', 8, 9), b.toString('hex', 9, 10),
+                b.toString('hex', 10, 11), b.toString('hex', 11, 12), b.toString('hex', 12, 13),
+                b.toString('hex', 13, 14), b.toString('hex', 14, 15), b.toString('hex', 15, 16));
         } else if (format === 'braced' || format === 'b') {
             return util.format('{%s}', this.toString());
         } else if (format === 'no-hyphen') {


### PR DESCRIPTION
Add a format for GUIDs for the *windows* Rust crate, like so:
```rust
// {f4666fdb-ad36-4d5f-99d6-80c83492f58d}
const __NAME__: GUID = GUID {data1: 0xf4666fdb, data2: 0xad36, data3: 0x4d5f, data4: [0x99, 0xd6, 0x80, 0xc8, 0x34, 0x92, 0xf5, 0x8d]};
```
