### PR TITLE
Fix test results publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
         TEST_RESULTS_PATH: ${{ github.workspace }}/.vscode-test/test-results.xml
 
     - name: Publish test results
+      if: github.repository_owner == 'heaths'
       uses: dorny/test-reporter@v1
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.vscode-channel }}


### PR DESCRIPTION
PRs run against forks get a read-only GITHUB_TOKEN, so workflows can
only publish test results if they are run in the context of
heaths/vscode-guid.
